### PR TITLE
Revert "ci: updated release action to only occur on main"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,6 @@
 name: Release
 
-on:
-  # Event for the workflow to run on
-  push:
-    branches:
-      - 'main'
+on: [push]
 
 jobs:
   release:


### PR DESCRIPTION
This reverts commit e6b3a8f6ab0355f3c74240a71164fe2b22ef68ca.

This revert has been applied so that auto can be used for canary and pre-releases from different branches.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.6--canary.3.731c4bd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-tailwind-autodocs@1.0.6--canary.3.731c4bd.0
  # or 
  yarn add storybook-addon-tailwind-autodocs@1.0.6--canary.3.731c4bd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
