### PR TITLE
ci: resolve build failure 

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           node-version: '18.x'
 
+      # Run build
+      - name: Build Storybook
+        run: npm run build
+
       #👇 Add Storybook build and deploy to GitHub Pages as a step in the workflow
       - uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
         with:


### PR DESCRIPTION
This fixes an issue where the storybook to GitHub pages deploy was not working; we needed to run npm run build first.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.7--canary.4.a380e43.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-tailwind-autodocs@1.0.7--canary.4.a380e43.0
  # or 
  yarn add storybook-addon-tailwind-autodocs@1.0.7--canary.4.a380e43.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
