### PR TITLE
Add unit tests for the key helper functions 

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -30,6 +30,10 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      # Run Tests
+      - name: Run tests
+        run: npm test
+
       # Run build
       - name: Build Storybook
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install dependencies
         run: npm install --ignore-scripts
 
+      - name: Run tests
+        run: npm test
+
       - name: Create Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "typescript": "^5.4.2",
         "unplugin": "^1.12.0",
         "vite": "^5.3.5",
+        "vitest": "^2.0.5",
         "zx": "^7.2.3"
       }
     },
@@ -71,14 +72,13 @@
       }
     },
     "node_modules/@ampproject/remapping": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-      "integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@jridgewell/gen-mapping": "^0.1.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -401,20 +401,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
@@ -2919,14 +2905,14 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-      "integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.0",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
       },
       "engines": {
         "node": ">=6.0.0"
@@ -4724,6 +4710,84 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.0.5.tgz",
+      "integrity": "sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.0.5.tgz",
+      "integrity": "sha512-TfRfZa6Bkk9ky4tW0z20WKXFEwwvWhRY+84CnSEtq4+3ZvDlJyY32oNTJtM7AW9ihW90tX/1Q78cb6FjoAs+ig==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.0.5",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
+      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.5",
+        "estree-walker": "^3.0.3",
+        "loupe": "^3.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/loupe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
+      "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.0.5.tgz",
+      "integrity": "sha512-SgCPUeDFLaM0mIUHfaArq8fD2WbaXG/zVXjRupthYfYGzc8ztbFbu6dUNOblBG7XLMR1kEhS/DNnfCZ2IhdDew==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.5",
+        "magic-string": "^0.30.10",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vitest/spy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.0.tgz",
@@ -6145,11 +6209,10 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -11194,6 +11257,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -11355,6 +11424,12 @@
         "node": "*"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -11363,6 +11438,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
+      "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==",
+      "dev": true
     },
     "node_modules/storybook": {
       "version": "8.2.8",
@@ -11674,20 +11755,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/sucrase/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
-      "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/sucrase/node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -11976,11 +12043,35 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "dev": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.0.tgz",
+      "integrity": "sha512-KIKExllK7jp3uvrNtvRBYBWBOAXSX8ZvoaD8T+7KB/QHIuoJW3Pmr60zucywjAlMb5TeXUkcs/MWeWLu0qvuAQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tinyspy": {
       "version": "2.2.1",
@@ -13076,6 +13167,353 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.0.5.tgz",
+      "integrity": "sha512-LdsW4pxj0Ot69FAoXZ1yTnA9bjGohr2yNBU7QKRxpz8ITSkhuDl6h3zS/tvgz4qrNjeRnvrWeXQ8ZF7Um4W00Q==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.5",
+        "pathe": "^1.1.2",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.0.5.tgz",
+      "integrity": "sha512-8GUxONfauuIdeSl5f9GTgVEpg5BTOlplET4WEDaeY2QBiN8wSm68vxN/tb5z405OwppfoCavnwXafiaYBC/xOA==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@vitest/expect": "2.0.5",
+        "@vitest/pretty-format": "^2.0.5",
+        "@vitest/runner": "2.0.5",
+        "@vitest/snapshot": "2.0.5",
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
+        "chai": "^5.1.1",
+        "debug": "^4.3.5",
+        "execa": "^8.0.1",
+        "magic-string": "^0.30.10",
+        "pathe": "^1.1.2",
+        "std-env": "^3.7.0",
+        "tinybench": "^2.8.0",
+        "tinypool": "^1.0.0",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.0.5",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.0.5",
+        "@vitest/ui": "2.0.5",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/vitest/node_modules/@vitest/expect": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.0.5.tgz",
+      "integrity": "sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.0.5",
+        "@vitest/utils": "2.0.5",
+        "chai": "^5.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/spy": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.0.5.tgz",
+      "integrity": "sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/utils": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.0.5.tgz",
+      "integrity": "sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.0.5",
+        "estree-walker": "^3.0.3",
+        "loupe": "^3.1.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+      "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/vitest/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/vitest/node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/vitest/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/loupe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.1.tgz",
+      "integrity": "sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/vitest/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/vitest/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vitest/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vitest/node_modules/tinyspy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.0.tgz",
+      "integrity": "sha512-q5nmENpTHgiPVd1cJDDc9cVoYN5x4vCvwT3FMilvKPKneCBZAxn2YWQjDF0UMcE9k0Cay1gBiDfTMU0g+mPMQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/walk-up-path": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
@@ -13192,6 +13630,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "build": "tsup",
     "build:watch": "npm run build -- --watch",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest",
     "start": "run-p build:watch \"storybook --quiet\"",
     "prerelease": "zx scripts/prepublish-checks.js",
     "release": "npm run build && auto shipit",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "typescript": "^5.4.2",
     "unplugin": "^1.12.0",
     "vite": "^5.3.5",
+    "vitest": "^2.0.5",
     "zx": "^7.2.3"
   },
   "publishConfig": {

--- a/src/addon/__tests__/helpers.test.ts
+++ b/src/addon/__tests__/helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { getFontFamiliesAsStrings, getPxValue, getSubtitle } from '../helpers';
+import {
+    extractFontSizes,
+    getFontFamiliesAsStrings,
+    getPxValue,
+    getSubtitle,
+} from '../helpers';
 import allColors from 'tailwindcss/colors';
 
 describe('getFontFamiliesAsStrings', () => {
@@ -169,5 +174,48 @@ describe('getPxValue', () => {
 
     it('should handle empty string correctly', () => {
         expect(() => getPxValue('')).toThrow('Invalid size format: ');
+    });
+});
+
+describe('extractFontSizes', () => {
+    it('should extract and sort font sizes correctly', () => {
+        const fontSizes = { sm: '0.875rem', lg: '1.25rem', md: '1rem' };
+        const result = extractFontSizes(fontSizes);
+        expect(result).toEqual({ sm: '14px', md: '16px', lg: '20px' });
+    });
+
+    it('should handle array font sizes correctly', () => {
+        const fontSizes = { sm: ['0.875rem'], lg: ['1.25rem', '1.5rem'] };
+        const result = extractFontSizes(fontSizes);
+        expect(result).toEqual({ sm: '14px', lg: '20px' });
+    });
+
+    it('should handle font sizes with default line heights correctly', () => {
+        const fontSizes = { sm: ['14px', '20px'], lg: ['20px', '28px'] };
+        const result = extractFontSizes(fontSizes);
+        expect(result).toEqual({ sm: '14px', lg: '20px' });
+    });
+
+    it('should handle font sizes with additional properties correctly', () => {
+        const fontSizes = {
+            '2xl': [
+                '1.5rem',
+                {
+                    lineHeight: '2rem',
+                    letterSpacing: '-0.01em',
+                    fontWeight: '500',
+                },
+            ],
+            '3xl': [
+                '1.875rem',
+                {
+                    lineHeight: '2.25rem',
+                    letterSpacing: '-0.02em',
+                    fontWeight: '700',
+                },
+            ],
+        };
+        const result = extractFontSizes(fontSizes);
+        expect(result).toEqual({ '2xl': '24px', '3xl': '30px' });
     });
 });

--- a/src/addon/__tests__/helpers.test.ts
+++ b/src/addon/__tests__/helpers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { getFontFamiliesAsStrings } from '../helpers';
+
+describe('getFontFamiliesAsStrings', () => {
+    it('should convert font families to strings correctly', () => {
+        const fontFamilies = {
+            sans: ['Helvetica', 'Arial'],
+            serif: ['Georgia', 'Times'],
+        };
+        const result = getFontFamiliesAsStrings(fontFamilies);
+        expect(result).toEqual({
+            sans: 'Helvetica, Arial',
+            serif: 'Georgia, Times',
+        });
+    });
+
+    it('should convert empty arrays to empty string', () => {
+        const fontFamilies: Record<string, string[]> = {
+            sans: [],
+            serif: [],
+        };
+        const result = getFontFamiliesAsStrings(fontFamilies);
+        expect(result).toEqual({
+            sans: '',
+            serif: '',
+        });
+    });
+
+    it('should handle single font family correctly', () => {
+        const fontFamilies = {
+            sans: ['Helvetica'],
+            serif: ['Georgia'],
+        };
+        const result = getFontFamiliesAsStrings(fontFamilies);
+        expect(result).toEqual({
+            sans: 'Helvetica',
+            serif: 'Georgia',
+        });
+    });
+
+    it('should handle multiple font families correctly', () => {
+        const fontFamilies = {
+            sans: ['Helvetica', 'Arial', 'Verdana'],
+            serif: ['Georgia', 'Times', 'Courier'],
+        };
+        const result = getFontFamiliesAsStrings(fontFamilies);
+        expect(result).toEqual({
+            sans: 'Helvetica, Arial, Verdana',
+            serif: 'Georgia, Times, Courier',
+        });
+    });
+
+    it('should handle spaces in font family names correctly', () => {
+        const fontFamilies = {
+            sans: ['Helvetica Neue', 'Arial Black'],
+            serif: ['Times New Roman', 'Courier New'],
+        };
+        const result = getFontFamiliesAsStrings(fontFamilies);
+        expect(result).toEqual({
+            sans: 'Helvetica Neue, Arial Black',
+            serif: 'Times New Roman, Courier New',
+        });
+    });
+});

--- a/src/addon/__tests__/helpers.test.ts
+++ b/src/addon/__tests__/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { getFontFamiliesAsStrings } from '../helpers';
+import { getFontFamiliesAsStrings, getSubtitle } from '../helpers';
+import allColors from 'tailwindcss/colors';
 
 describe('getFontFamiliesAsStrings', () => {
     it('should convert font families to strings correctly', () => {
@@ -60,5 +61,42 @@ describe('getFontFamiliesAsStrings', () => {
             sans: 'Helvetica Neue, Arial Black',
             serif: 'Times New Roman, Courier New',
         });
+    });
+});
+
+describe('getSubtitle', () => {
+    it('should return "Default color from Tailwind CSS" for default Tailwind colors', () => {
+        const colorLabel = 'red';
+        const values = allColors.red;
+        const result = getSubtitle(colorLabel, values);
+        expect(result).toBe('Default color from Tailwind CSS');
+    });
+
+    it('should return "Custom color" for non-default colors', () => {
+        const colorLabel = 'customRed';
+        const values = { 500: '#ff0000' };
+        const result = getSubtitle(colorLabel, values);
+        expect(result).toBe('Custom color');
+    });
+
+    it('should return "Custom color" for colors not in Tailwind CSS', () => {
+        const colorLabel = 'nonExistentColor';
+        const values = { 500: '#123456' };
+        const result = getSubtitle(colorLabel, values);
+        expect(result).toBe('Custom color');
+    });
+
+    it('should handle empty values correctly', () => {
+        const colorLabel = 'red';
+        const values = {};
+        const result = getSubtitle(colorLabel, values);
+        expect(result).toBe('Custom color');
+    });
+
+    it('should return "Custom color" for extended Tailwind colors', () => {
+        const colorLabel = 'red';
+        const values = { ...allColors.red, 600: '#ff6666' }; // Extending the red color
+        const result = getSubtitle(colorLabel, values);
+        expect(result).toBe('Custom color');
     });
 });

--- a/src/addon/__tests__/helpers.test.ts
+++ b/src/addon/__tests__/helpers.test.ts
@@ -4,6 +4,8 @@ import {
     getFontFamiliesAsStrings,
     getPxValue,
     getSubtitle,
+    getTypography,
+    groupTailwindColors,
 } from '../helpers';
 import allColors from 'tailwindcss/colors';
 
@@ -217,5 +219,121 @@ describe('extractFontSizes', () => {
         };
         const result = extractFontSizes(fontSizes);
         expect(result).toEqual({ '2xl': '24px', '3xl': '30px' });
+    });
+});
+
+describe('getTypography', () => {
+    it('should correctly extract and convert font sizes', () => {
+        const fontSizes = { sm: '0.875rem', lg: '1.25rem' };
+        const fontWeights = { normal: '400', bold: '700' };
+        const fontFamilies = { sans: ['Helvetica', 'Arial'] };
+        const result = getTypography(fontSizes, fontWeights, fontFamilies);
+        expect(result.size).toEqual({ sm: '14px', lg: '20px' });
+    });
+
+    it('should correctly convert font families to strings', () => {
+        const fontSizes = { sm: '0.875rem' };
+        const fontWeights = { normal: '400' };
+        const fontFamilies = {
+            sans: ['Helvetica', 'Arial'],
+            serif: ['Georgia', 'Times'],
+        };
+        const result = getTypography(fontSizes, fontWeights, fontFamilies);
+        expect(result.type).toEqual({
+            sans: 'Helvetica, Arial',
+            serif: 'Georgia, Times',
+        });
+    });
+
+    it('should correctly return the typography object', () => {
+        const fontSizes = { sm: '0.875rem' };
+        const fontWeights = { normal: '400' };
+        const fontFamilies = { sans: ['Helvetica', 'Arial'] };
+        const result = getTypography(fontSizes, fontWeights, fontFamilies);
+        expect(result).toEqual({
+            type: { sans: 'Helvetica, Arial' },
+            weight: { normal: '400' },
+            size: { sm: '14px' },
+        });
+    });
+});
+
+describe('groupTailwindColors', () => {
+    it('should group colors where all values are strings', () => {
+        const colors = { red: '#ff0000', blue: '#0000ff' };
+        const result = groupTailwindColors(colors);
+        expect(result).toEqual([
+            { key: 'red', value: { red: '#ff0000' }, subtitle: 'Custom color' },
+            {
+                key: 'blue',
+                value: { blue: '#0000ff' },
+                subtitle: 'Custom color',
+            },
+        ]);
+    });
+
+    it('should group colors where some values are objects', () => {
+        const colors = { red: { 500: '#ff0000' }, blue: '#0000ff' };
+        const result = groupTailwindColors(colors);
+        expect(result).toEqual([
+            { key: 'red', value: { 500: '#ff0000' }, subtitle: 'Custom color' },
+            {
+                key: 'blue',
+                value: { blue: '#0000ff' },
+                subtitle: 'Custom color',
+            },
+        ]);
+    });
+
+    it('should group colors with a mix of strings and objects', () => {
+        const colors = {
+            red: { 500: '#ff0000' },
+            blue: '#0000ff',
+            green: { 300: '#00ff00' },
+        };
+        const result = groupTailwindColors(colors);
+        expect(result).toEqual([
+            { key: 'red', value: { 500: '#ff0000' }, subtitle: 'Custom color' },
+            {
+                key: 'blue',
+                value: { blue: '#0000ff' },
+                subtitle: 'Custom color',
+            },
+            {
+                key: 'green',
+                value: { 300: '#00ff00' },
+                subtitle: 'Custom color',
+            },
+        ]);
+    });
+
+    it('should correctly set the subtitle for default and custom colors', () => {
+        const twReds = {
+            '50': '#fef2f2',
+            '100': '#fee2e2',
+            '200': '#fecaca',
+            '300': '#fca5a5',
+            '400': '#f87171',
+            '500': '#ef4444',
+            '600': '#dc2626',
+            '700': '#b91c1c',
+            '800': '#991b1b',
+            '900': '#7f1d1d',
+            '950': '#450a0a',
+        };
+        const colors = { red: twReds, customColor: '#123456' };
+        const result = groupTailwindColors(colors);
+        expect(result).toEqual([
+            {
+                key: 'red',
+                value: twReds,
+                subtitle: 'Default color from Tailwind CSS',
+            },
+            {
+                key: 'customColor',
+                value: { customColor: '#123456' },
+                subtitle: 'Custom color',
+            },
+        ]);
     });
 });

--- a/src/addon/__tests__/helpers.test.ts
+++ b/src/addon/__tests__/helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getFontFamiliesAsStrings, getSubtitle } from '../helpers';
+import { getFontFamiliesAsStrings, getPxValue, getSubtitle } from '../helpers';
 import allColors from 'tailwindcss/colors';
 
 describe('getFontFamiliesAsStrings', () => {
@@ -98,5 +98,76 @@ describe('getSubtitle', () => {
         const values = { ...allColors.red, 600: '#ff6666' }; // Extending the red color
         const result = getSubtitle(colorLabel, values);
         expect(result).toBe('Custom color');
+    });
+});
+
+describe('getPxValue', () => {
+    it('should convert rem to px correctly', () => {
+        expect(getPxValue('1rem')).toBe('16px');
+        expect(getPxValue('0.875rem')).toBe('14px');
+    });
+
+    it('should convert em to px correctly', () => {
+        expect(getPxValue('1em')).toBe('16px');
+        expect(getPxValue('0.875em')).toBe('14px');
+    });
+
+    it('should convert pt to px correctly', () => {
+        expect(getPxValue('1pt')).toBe('1.3333px');
+        expect(getPxValue('12pt')).toBe('16px');
+    });
+
+    it('should convert cm to px correctly', () => {
+        expect(getPxValue('1cm')).toBe('37.7953px');
+        expect(getPxValue('0.5cm')).toBe('18.8976px');
+    });
+
+    it('should convert mm to px correctly', () => {
+        expect(getPxValue('1mm')).toBe('3.7795px');
+        expect(getPxValue('10mm')).toBe('37.7953px');
+    });
+
+    it('should convert in to px correctly', () => {
+        expect(getPxValue('1in')).toBe('96px');
+        expect(getPxValue('0.5in')).toBe('48px');
+    });
+
+    it('should convert pc to px correctly', () => {
+        expect(getPxValue('1pc')).toBe('16px');
+        expect(getPxValue('2pc')).toBe('32px');
+    });
+
+    it('should convert % to px correctly', () => {
+        expect(getPxValue('100%')).toBe('16px');
+        expect(getPxValue('50%')).toBe('8px');
+    });
+
+    it('should convert 0rem to 0px', () => {
+        expect(getPxValue('0rem')).toBe('0px');
+    });
+
+    it('should convert negative rem values correctly', () => {
+        expect(getPxValue('-1rem')).toBe('-16px');
+    });
+
+    it('should convert fractional rem values correctly', () => {
+        expect(getPxValue('0.5rem')).toBe('8px');
+        expect(getPxValue('1.5rem')).toBe('24px');
+    });
+
+    it('should throw an error for invalid size format', () => {
+        expect(() => getPxValue('invalid')).toThrow(
+            'Invalid size format: invalid'
+        );
+        expect(() => getPxValue('16')).toThrow('Invalid size format: 16');
+    });
+
+    it('should throw an error for unsupported units', () => {
+        expect(() => getPxValue('1vw')).toThrow('Unsupported unit: vw');
+        expect(() => getPxValue('1inch')).toThrow('Unsupported unit: inch');
+    });
+
+    it('should handle empty string correctly', () => {
+        expect(() => getPxValue('')).toThrow('Invalid size format: ');
     });
 });

--- a/src/addon/helpers.ts
+++ b/src/addon/helpers.ts
@@ -26,15 +26,6 @@ export const groupTailwindColors = (colors: Record<string, any>) => {
     }));
 };
 
-// TODO: Add ability to turn this off based off user input
-const getSubtitle = (color: string): string => {
-    // FIXME: Slightly naive check, but it should work for now
-    const isDefaultColor = Object.keys(allColors).includes(color);
-    const defaultColorMessage = 'Default color from Tailwind CSS';
-    const customColorMessage = 'Custom color';
-    return isDefaultColor ? defaultColorMessage : customColorMessage;
-};
-
 export interface Typography {
     type: Record<string, string>;
     weight: Record<string, string>;
@@ -97,4 +88,25 @@ export const getFontFamiliesAsStrings = (
         fontFamiliesAsStrings[key] = fontFamilies[key].join(', ');
     }
     return fontFamiliesAsStrings;
+};
+
+// TODO: Add ability to turn this off based off user input
+export const getSubtitle = (
+    colorLabel: string,
+    values: Record<string, string>
+): string => {
+    const defaultColorMessage = 'Default color from Tailwind CSS';
+    const customColorMessage = 'Custom color';
+
+    if (!allColors.hasOwnProperty(colorLabel)) {
+        return customColorMessage;
+    }
+
+    // FIXME: TS error
+    const tailwindColors = allColors[colorLabel];
+
+    const isDefaultColor =
+        JSON.stringify(tailwindColors) === JSON.stringify(values);
+
+    return isDefaultColor ? defaultColorMessage : customColorMessage;
 };

--- a/src/addon/helpers.ts
+++ b/src/addon/helpers.ts
@@ -89,7 +89,7 @@ const convertRemToPx = (rem: string): string => {
     return `${parseFloat(rem) * TAILWIND_BASE_RATIO}px`;
 };
 
-const getFontFamiliesAsStrings = (
+export const getFontFamiliesAsStrings = (
     fontFamilies: Record<string, string[]>
 ): Record<string, string> => {
     const fontFamiliesAsStrings: Record<string, string> = {};

--- a/src/addon/helpers.ts
+++ b/src/addon/helpers.ts
@@ -1,6 +1,5 @@
 import allColors from 'tailwindcss/colors';
 
-export const TAILWIND_BASE_RATIO = 16;
 /**
  * Group the colors from the resolved Tailwind CSS configuration.
  *
@@ -18,11 +17,11 @@ export const groupTailwindColors = (colors: Record<string, any>) => {
             groupedColors[key] = { [key]: value };
         }
     }
-    // Tranform into an array of objects with key, value, and subtitle
+    // Transform into an array of objects with key, value, and subtitle
     return Object.entries(groupedColors).map(([key, value]) => ({
         key,
         value,
-        subtitle: getSubtitle(key),
+        subtitle: getSubtitle(key, value),
     }));
 };
 
@@ -50,15 +49,15 @@ export const getTypography = (
  * Extract the font sizes from the resolved Tailwind CSS configuration.
  * @param fontSizes
  */
-const extractFontSizes = (
+export const extractFontSizes = (
     fontSizes: Record<string, any>
 ): Record<string, string> => {
     const extractedFontSizes: Record<string, string> = {};
     for (const key in fontSizes) {
         if (Array.isArray(fontSizes[key])) {
-            extractedFontSizes[key] = convertRemToPx(fontSizes[key][0]);
+            extractedFontSizes[key] = getPxValue(fontSizes[key][0]);
         } else {
-            extractedFontSizes[key] = convertRemToPx(fontSizes[key]);
+            extractedFontSizes[key] = getPxValue(fontSizes[key]);
         }
     }
 
@@ -76,8 +75,35 @@ const extractFontSizes = (
     return sortedFontSizesObj;
 };
 
-const convertRemToPx = (rem: string): string => {
-    return `${parseFloat(rem) * TAILWIND_BASE_RATIO}px`;
+// TODO: Add support for other units (or use library which already does this)
+export const TAILWIND_BASE_RATIO = 16;
+const unitConversionRatios: Record<string, number> = {
+    rem: TAILWIND_BASE_RATIO,
+    em: TAILWIND_BASE_RATIO,
+    px: 1,
+    pt: 1.33333, // 1pt = 1.33333px
+    cm: 37.7953, // 1cm = 37.7953px
+    mm: 3.77953, // 1mm = 3.77953px
+    in: 96, // 1in = 96px
+    pc: 16, // 1pc = 16px
+    '%': 0.16, // Assuming 1% of 16px base font size
+};
+export const getPxValue = (size: string): string => {
+    const unitMatch = size.match(/[\d.]+(\D+)$/);
+    if (!unitMatch) {
+        throw new Error(`Invalid size format: ${size}`);
+    }
+
+    const value = parseFloat(size);
+    const unit = unitMatch[1];
+
+    if (!unitConversionRatios[unit]) {
+        throw new Error(`Unsupported unit: ${unit}`);
+    }
+
+    const pxValue = value * unitConversionRatios[unit];
+    const roundedPxValue = parseFloat(pxValue.toFixed(4));
+    return `${roundedPxValue}px`;
 };
 
 export const getFontFamiliesAsStrings = (


### PR DESCRIPTION
This adds some test coverage for all the core helper functions.

Some more tests, such as integration tests that check the compile and config transformation as a whole are probably still necessary — but this gives us a good base to work with.