### PR TITLE
feat: use JSX syntax in generated CSF and fix virtual module transform

### DIFF
--- a/src/addon/README.md
+++ b/src/addon/README.md
@@ -77,5 +77,4 @@ npm test
 ## Future Work
 
 - Add integration and e2e tests (if valuable)
-- Fix JSX support in plugin (use `<Typography />` instead of `createElement(Typography)`)
 - Add more Tailwind sections (screens, spacing, borderRadius, etc.)

--- a/src/addon/core/theme-loader/loaders/ConfigLoader.ts
+++ b/src/addon/core/theme-loader/loaders/ConfigLoader.ts
@@ -16,7 +16,7 @@ export class ConfigLoader extends ThemeLoader {
 
     public baseResolveId(filePath: string): string | null {
         if (this.isRegexMatch(filePath)) {
-            return VIRTUAL_FILE_PREFIX + filePath; // TODO: Why doesn't this work if its not jsx?
+            return VIRTUAL_FILE_PREFIX + filePath;
         }
         return null;
     }

--- a/src/addon/core/theme-loader/loaders/CssLoader.ts
+++ b/src/addon/core/theme-loader/loaders/CssLoader.ts
@@ -30,7 +30,7 @@ export class CssLoader extends ThemeLoader {
         try {
             const content = readFileSync(filePath, 'utf-8');
             if (!TAILWIND_IMPORT_REGEX.test(content)) return null;
-            return VIRTUAL_FILE_PREFIX + filePath; // TODO: Why doesn't this work if its not jsx?
+            return VIRTUAL_FILE_PREFIX + filePath;
         } catch {
             return null;
         }

--- a/src/addon/core/theme-transformer/CsfGenerator.ts
+++ b/src/addon/core/theme-transformer/CsfGenerator.ts
@@ -15,7 +15,6 @@ export class CsfGenerator {
     }
 
     public generate(colors: Color[], typography: Typography): string {
-        // If we're forcing single, then generate one story export
         if (this.addonOptions.forceSingleDoc !== undefined) {
             return this.generateSingleStory(
                 colors,
@@ -23,7 +22,6 @@ export class CsfGenerator {
                 sanitizeExportName(this.addonOptions.forceSingleDoc.name)
             );
         }
-        // Otherwise generate story per enabled section
         return this.generateMultiStory(colors, typography);
     }
 
@@ -31,8 +29,7 @@ export class CsfGenerator {
         return `
         import { styled, ThemeProvider, themes, ensure } from 'storybook/theming';
         import { ColorPalette, ColorItem, Typeset } from '@storybook/addon-docs/blocks';
-        import { createElement } from 'react';
-        
+
         export default {
             title: 'Theme',
             parameters: {
@@ -40,12 +37,14 @@ export class CsfGenerator {
                 options: { bottomPanelHeight: 0 }
             },
             decorators: [
-                (Story) => {
-                    return createElement(ThemeProvider, { theme: ensure(themes.light) }, createElement(Story));
-                }
+                (Story) => (
+                    <ThemeProvider theme={ensure(themes.light)}>
+                        <Story />
+                    </ThemeProvider>
+                )
             ]
         };
-        
+
         const Wrapper = styled.div(({ theme }) => ({
           background: theme.background.content,
           display: 'flex',
@@ -57,13 +56,13 @@ export class CsfGenerator {
           gap: '3rem',
           [\`@media (min-width: 600px)\`]: {}
         }));
-        
+
         const Container = styled.div(() => ({
             maxWidth: '1000px',
             width: '100%',
             minWidth: '0px'
         }));
-        
+
         // Inspired by https://github.com/storybookjs/storybook/blob/main/code/addons/docs/src/blocks/components/DocsPage.tsx
         // Basically what the toGlobalSelector('h1') renders
         const Title = styled.h1(({ theme }) => ({
@@ -90,7 +89,7 @@ export class CsfGenerator {
             fontSize: \`\${theme.typography.size.l1}px\`,
             fontWeight: theme.typography.weight.bold,
         }));
-        
+
         const NoneDetectedText = styled.div(({ theme }) => ({
             color: theme.color.defaultText,
             fontStyle: 'italic',
@@ -103,14 +102,14 @@ export class CsfGenerator {
             WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
             WebkitOverflowScrolling: 'touch',
         }));
-        
+
         const HorizontalRule = styled.div(({ theme }) => ({
               border: '0 none',
               borderTop: \`1px solid \${theme.appBorderColor}\`,
               height: 4,
               paddingBottom: '30px',
         }));
-        
+
         const FontHeaderSection = styled.div(({ theme }) => ({
             fontFamily: theme.typography.fonts.base,
             fontSize: \`\${theme.typography.size.s3}px\`,
@@ -137,13 +136,13 @@ export class CsfGenerator {
         enabledSections.includes('Colors')
             ? `
     export const Colors = {
-        render: () => {
-            return createElement(Wrapper, null,
-                createElement(Container, null,
+        render: () => (
+            <Wrapper>
+                <Container>
                     ${this.renderColors(colors)}
-                )
-            );
-        }
+                </Container>
+            </Wrapper>
+        )
     };
     `
             : ''
@@ -152,14 +151,12 @@ export class CsfGenerator {
         enabledSections.includes('Typography')
             ? `
     export const Typography = {
-        render: () => createElement(
-            Wrapper,
-            null,
-            createElement(
-                Container,
-                null,
-                ${this.renderTypography(typography)}
-            )
+        render: () => (
+            <Wrapper>
+                <Container>
+                    ${this.renderTypography(typography)}
+                </Container>
+            </Wrapper>
         )
     };
     `
@@ -182,21 +179,20 @@ export class CsfGenerator {
             if (section === 'Typography') {
                 elements.push(this.renderTypography(typography));
             }
-            // Add HorizontalRule if not the last section
             if (idx < enabledSections.length - 1) {
-                elements.push('createElement(HorizontalRule, null)');
+                elements.push('<HorizontalRule />');
             }
         });
         return `
         ${this.generateCommonCode()}
         export const ${singleExportName} = {
-            render: () => {
-                return createElement(Wrapper, null,
-                    createElement(Container, null,
-                        ${elements.join(',\n')}
-                    )
-                );
-            }
+            render: () => (
+                <Wrapper>
+                    <Container>
+                        ${elements.join('\n')}
+                    </Container>
+                </Wrapper>
+            )
         };
         `;
     }
@@ -204,24 +200,28 @@ export class CsfGenerator {
     private renderColors(colors: Color[]): string {
         const hasColors = colors.length > 0;
         return `
-        createElement(Title, null, 'Colors'),
-                        createElement('br'),
-                         ${
-                             hasColors
-                                 ? `createElement(ColorPalette, null,
-                                ${JSON.stringify(colors)}.map((color) =>
-                                    createElement(ColorItem, {
-                                        key: color.baseName,
-                                        title: color.baseName,
-                                        subtitle: color.subtitle,
-                                        colors: color.shades
-                                    })
-                                )
-                            )`
-                                 : `createElement(NoneDetectedText, null,
-                                'No colors detected. To see a color, add it to your Tailwind configuration, or ensure Tailwind\\'s defaults are not being overridden.'
-                            )`
-                         }
+        <Title>Colors</Title>
+        <br />
+        ${
+            hasColors
+                ? `
+        <ColorPalette>
+            {${JSON.stringify(colors)}.map((color) => (
+                <ColorItem
+                    key={color.baseName}
+                    title={color.baseName}
+                    subtitle={color.subtitle}
+                    colors={color.shades}
+                />
+            ))}
+        </ColorPalette>
+        `
+                : `
+        <NoneDetectedText>
+            No colors detected. To see a color, add it to your Tailwind configuration, or ensure Tailwind's defaults are not being overridden.
+        </NoneDetectedText>
+        `
+        }
         `;
     }
 
@@ -231,62 +231,46 @@ export class CsfGenerator {
         const fontFamilies = Object.entries(typography.type);
         const sampleText =
             'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
-
         const hasFontFamily = fontFamilies.length > 0; // TODO: Update this handling so that it handles just weight and/or just size
 
         return `
-        createElement(Title, null, 'Typography'),
-        createElement('br'),
+        <Title>Typography</Title>
+        <br />
         ${
             hasFontFamily
-                ? `${JSON.stringify(fontFamilies)}.map(([label, fontFamily], familyIndex) =>
-            [
-                createElement(
-                    'div',
-                    { key: label },
-                    createElement(
-                        FontHeaderSection,
-                        null,
-                        createElement(
-                            'div',
-                            null,
-                            createElement('b', null, 'Font Face: '),
-                            createElement(
-                                'span',
-                                { style: { fontFamily } },
-                                label
-                            )
-                        ),
-                        createElement(
-                            'div',
-                            null,
-                            createElement('b', null, 'Weights: '),
-                            ${JSON.stringify(fontWeights)}.map(([weightLabel, weightValue], index) =>
-                                createElement(
-                                    'span',
-                                    {
-                                        key: weightLabel,
-                                        style: { fontWeight: weightValue, fontFamily }
-                                    },
-                                    \`\${weightValue}(\${weightLabel})\${index < ${fontWeights.length} - 1 ? ', ' : ''}\`
-                                )
-                            )
-                        )
-                     ),
-                    createElement(Typeset, {
-                        fontSizes: ${JSON.stringify(fontSizes)},
-                        fontWeight: 400,
-                        sampleText: '${sampleText}',
-                        fontFamily
-                    })
-                ),
-                familyIndex < ${fontFamilies.length} - 1 ? createElement(HorizontalRule, { key: \`hr-\${label}\` }) : null
-            ]
-        ).flat()`
-                : `createElement(NoneDetectedText, null,
-                    'No font families detected. To see typography, add a font family to your Tailwind configuration, or ensure Tailwind\\'s defaults are not being overridden.'
-                )`
+                ? `
+        {${JSON.stringify(fontFamilies)}.map(([label, fontFamily], familyIndex) => (
+            <div key={label}>
+                <FontHeaderSection>
+                    <div>
+                        <b>Font Face: </b>
+                        <span style={{ fontFamily }}>{label}</span>
+                    </div>
+                    <div>
+                        <b>Weights: </b>
+                        {${JSON.stringify(fontWeights)}.map(([weightLabel, weightValue], index) => (
+                            <span key={weightLabel} style={{ fontWeight: weightValue, fontFamily }}>
+                                {\`\${weightValue}(\${weightLabel})\${index < ${fontWeights.length} - 1 ? ', ' : ''}\`}
+                            </span>
+                        ))}
+                    </div>
+                </FontHeaderSection>
+                <Typeset
+                    fontSizes={${JSON.stringify(fontSizes)}}
+                    fontWeight={400}
+                    sampleText="${sampleText}"
+                    fontFamily={fontFamily}
+                />
+                {familyIndex < ${fontFamilies.length} - 1 && <HorizontalRule />}
+            </div>
+        ))}
+        `
+                : `
+        <NoneDetectedText>
+            No font families detected. To see typography, add a font family to your Tailwind configuration, or ensure Tailwind's defaults are not being overridden.
+        </NoneDetectedText>
+        `
         }
-    `;
+        `;
     }
 }

--- a/src/addon/tests/unit/core/theme-transformer/CsfGenerator.test.ts
+++ b/src/addon/tests/unit/core/theme-transformer/CsfGenerator.test.ts
@@ -116,7 +116,7 @@ describe('CsfGenerator', () => {
         };
         const generator = new CsfGenerator(mockAddonOptions);
         const result = generator.generate(colors, typography);
-        expect(result).toContain('createElement(HorizontalRule, null)');
+        expect(result).toContain('<HorizontalRule />');
     });
 
     it('does not include HorizontalRule after last section in single story', () => {
@@ -132,9 +132,7 @@ describe('CsfGenerator', () => {
             weight: {},
             size: {},
         });
-        const hrCount = (
-            result.match(/createElement\(HorizontalRule, null\)/g) || []
-        ).length;
+        const hrCount = (result.match(/<HorizontalRule \/>/g) || []).length;
         expect(hrCount).toBe(0);
     });
 
@@ -166,7 +164,7 @@ describe('CsfGenerator', () => {
         });
         expect(result).toContain('export const AllTheme');
         expect(result).toContain('FontHeaderSection');
-        expect(result).not.toContain('createElement(ColorItem');
-        expect(result).not.toContain("createElement(Title, null, 'Colors')");
+        expect(result).not.toContain('<ColorItem');
+        expect(result).not.toContain('<Title>Colors</Title>');
     });
 });

--- a/src/addon/unplugin.ts
+++ b/src/addon/unplugin.ts
@@ -1,4 +1,5 @@
 import { createUnplugin } from 'unplugin';
+import { transformWithEsbuild } from 'vite';
 import { VIRTUAL_FILE_PREFIX } from './constants';
 import { PluginOptions } from './types';
 import { CsfGenerator, ThemeTransformer } from './core/theme-transformer';
@@ -14,15 +15,15 @@ const unplugin = createUnplugin((options: PluginOptions) => {
         resolveId(id) {
             const baseResolveId = themeLoader.baseResolveId(id);
             if (baseResolveId === null) return null;
-            return baseResolveId + '.js';
+            return baseResolveId + '.jsx';
         },
         loadInclude(id) {
             return id.startsWith(VIRTUAL_FILE_PREFIX);
         },
         async load(id) {
             if (id.startsWith(VIRTUAL_FILE_PREFIX)) {
-                // Remove the .js extension we added in resolveId method
-                const realPath = id.slice(VIRTUAL_FILE_PREFIX.length, -3);
+                // Remove the .jsx extension we added in resolveId method
+                const realPath = id.slice(VIRTUAL_FILE_PREFIX.length, -4);
 
                 // Watch the config file for all bundlers - mainly for webpack
                 if (this.addWatchFile) {
@@ -31,14 +32,21 @@ const unplugin = createUnplugin((options: PluginOptions) => {
                 const fullTailwindConfig =
                     await themeLoader.getTailwindTheme(realPath);
 
-                return themeTransformer.transformToCsf(fullTailwindConfig); // TODO: Why doesn't this work if its not jsx?
+                return themeTransformer.transformToCsf(fullTailwindConfig);
             }
         },
         vite: {
+            async transform(code, id) {
+                if (!id.startsWith(VIRTUAL_FILE_PREFIX)) return null;
+                return transformWithEsbuild(code, id, {
+                    loader: 'jsx',
+                    jsx: 'automatic',
+                });
+            },
             handleHotUpdate({ file, server }) {
                 if (themeLoader.isRegexMatch(file)) {
                     delete require.cache[file];
-                    const virtualModuleId = VIRTUAL_FILE_PREFIX + file + '.js';
+                    const virtualModuleId = VIRTUAL_FILE_PREFIX + file + '.jsx';
                     const module =
                         server.moduleGraph.getModuleById(virtualModuleId);
                     if (module) {

--- a/src/addon/unplugin.ts
+++ b/src/addon/unplugin.ts
@@ -1,5 +1,4 @@
 import { createUnplugin } from 'unplugin';
-import { transformWithEsbuild } from 'vite';
 import { VIRTUAL_FILE_PREFIX } from './constants';
 import { PluginOptions } from './types';
 import { CsfGenerator, ThemeTransformer } from './core/theme-transformer';
@@ -38,6 +37,7 @@ const unplugin = createUnplugin((options: PluginOptions) => {
         vite: {
             async transform(code, id) {
                 if (!id.startsWith(VIRTUAL_FILE_PREFIX)) return null;
+                const { transformWithEsbuild } = await import('vite');
                 return transformWithEsbuild(code, id, {
                     loader: 'jsx',
                     jsx: 'automatic',

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -48,7 +48,7 @@ export default defineConfig(async options => {
         // keep this line commented until https://github.com/egoist/tsup/issues/1270 is resolved
         // clean: options.watch ? false : true,
         clean: false,
-        external: ['tailwindcss'],
+        external: ['tailwindcss', 'vite'],
     };
 
     const configs: Options[] = [];


### PR DESCRIPTION
Code generation finally uses JSX rather than `createElement` 🎉 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.2--canary.23.6c9b5b0.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install storybook-addon-tailwind-autodocs@2.0.2--canary.23.6c9b5b0.0
  # or 
  yarn add storybook-addon-tailwind-autodocs@2.0.2--canary.23.6c9b5b0.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.2-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - feat: use JSX syntax in generated CSF and fix virtual module transform [#23](https://github.com/matanio/storybook-addon-tailwind-autodocs/pull/23) ([@matanio](https://github.com/matanio))
  
  #### Authors: 1
  
  - Matan Yosef ([@matanio](https://github.com/matanio))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
